### PR TITLE
Improve setup.sh and README

### DIFF
--- a/mmfakebench/README.md
+++ b/mmfakebench/README.md
@@ -44,10 +44,11 @@
    cd mmfakebench
    ```
 
-2. **Install dependencies:**
+2. **Run the setup script:**
    ```bash
-   pip install -r requirements.txt
+   ./setup.sh
    ```
+   *(You can run this script from any directory. It locates the repository root using Git and installs dependencies from `mmfakebench/requirements.txt`.)*
 
 3. **Configure API keys:**
    ```bash

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! ROOT_DIR="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"; then
+  echo "Error: setup.sh must be run inside a Git repository." >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+
+# Create virtual environment if it doesn't exist
+if [ ! -d .venv ]; then
+  python3 -m venv .venv
+fi
+
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r mmfakebench/requirements.txt
+
+echo "Environment setup complete."


### PR DESCRIPTION
## Summary
- add a setup.sh script that locates the repo root with git and installs requirements
- mention new setup script in the README

## Testing
- `bash -x /workspace/LVLM/setup.sh` *(fails: Cannot connect to proxy)*
- `pytest -q` *(fails: INTERNALERROR SystemExit 1)*

------
https://chatgpt.com/codex/tasks/task_e_684add57bcac8332ad7751dd76e10ab6